### PR TITLE
Add a link to GET endpoints without arguments.

### DIFF
--- a/flask_autodoc/templates/autodoc_default.html
+++ b/flask_autodoc/templates/autodoc_default.html
@@ -57,9 +57,15 @@
         <div class="mapping">
             <a id="rule-{{doc.rule|urlencode}}" class="rule"><h2>{{doc.rule|escape}}</h2></a>
             <ul class="methods">
-                    {% for method in doc.methods -%}
-                    <li class="method">{{method}}</li>
-                    {% endfor %}
+                {% for method in doc.methods -%}
+                    {% if method == 'GET' and doc.args == ['None'] %}
+                        <a href="{{doc.rule}}" class="getmethod">
+                    {% endif %}
+                        <li class="method">{{method}}</li>
+                    {% if method == 'GET' %}
+                        </a>
+                    {% endif %}
+                {% endfor %}
             </ul>
             <ul class="arguments">
                 {% for arg in doc.args %}


### PR DESCRIPTION
This means that its very easy to see the contents of an endpoint like this.